### PR TITLE
Update targeted_mbio_vblast_pipeline.def

### DIFF
--- a/targeted_mbio_vblast_pipeline.def
+++ b/targeted_mbio_vblast_pipeline.def
@@ -55,7 +55,7 @@ From:ubuntu:22.04
 	Rscript -e 'install.packages("readr")'
 
 #Downloading and extracting BLAST+
-	wget https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.15.0+-x64-linux.tar.gz -P /tmp/ && tar -zxvf /tmp/ncbi-blast-2.15.0+-x64-linux.tar.gz -C /blast/ && rm -r /tmp/ncbi-blast-2.15.0+-x64-linux.tar.gz
+	wget https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.15.0/ncbi-blast-2.15.0+-x64-linux.tar.gz -P /tmp/ && tar -zxvf /tmp/ncbi-blast-2.15.0+-x64-linux.tar.gz -C /blast/ && rm -r /tmp/ncbi-blast-2.15.0+-x64-linux.tar.gz
 
 
 #Setting up NCBI E-utilites


### PR DESCRIPTION
The link to Blast needed to be updated as the previous link no longer exists. Trying to build the container with this outdated link causes Blast to not be installed within the container. 